### PR TITLE
#19: [meta] Remove tcomb autodebugger (closes #19)

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -24,15 +24,6 @@ if (process.env.NODE_ENV === 'development') {
   // export for debug
   window.React = React;
 
-  // fail loudly
-  t.fail = function(message) {
-    if (!t.fail.failed) {
-      debugger; //eslint-disable-line no-debugger
-      t.fail.failed = true;
-    }
-    throw new TypeError(message);
-  };
-
   debug.enable(config.debug || '');
 } else {
   debug.disable();


### PR DESCRIPTION
Issue #19
## Test Plan
### tests performed
- App still working fine
- Adding a tcomb type mismatch shows in the console but doesn't trigger the debugger
- Enabling "pause on exceptions" and "pause on caught exceptions" in the DevTools triggers the debugger
